### PR TITLE
Fix the fallback probe to be really compatible with PHP 5.2

### DIFF
--- a/src/autostart.php
+++ b/src/autostart.php
@@ -10,7 +10,7 @@
  */
 
 if (!class_exists('BlackfireProbe', false) && !extension_loaded('blackfire')) {
-    require __DIR__.'/BlackfireProbe.php';
+    require dirname(__FILE__).'/BlackfireProbe.php';
 
     BlackfireProbe::getMainInstance();
 }


### PR DESCRIPTION
The BlackfireProbe polyfill was designed to be compatible with PHP 5.2, but its entry point destroys this by using ``__DIR__``