### PR TITLE
Fixed ReactHttpServer

### DIFF
--- a/src/Blackfire/Bridge/ReactHttpServer.php
+++ b/src/Blackfire/Bridge/ReactHttpServer.php
@@ -11,33 +11,63 @@
 
 namespace Blackfire\Bridge;
 
-use React\Http\Request;
-use React\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Class ReactHttpServer
+ *
+ * @package Blackfire\Bridge
+ */
 class ReactHttpServer
 {
-    public function handle(Request $request, Response $response)
+    /**
+     * @var \BlackfireProbe
+     */
+    private $probe;
+
+    /**
+     * Start profiling with Blackfire if header is present
+     *
+     * @param ServerRequestInterface $request
+     */
+    public function handleRequest(ServerRequestInterface $request)
     {
         $headers = array_change_key_case($request->getHeaders(), CASE_LOWER);
 
         // Only enable when the X-Blackfire-Query header is present
         if (!isset($headers['x-blackfire-query'])) {
-            return array();
+            return;
         }
 
-        $probe = new \BlackfireProbe($headers['x-blackfire-query']);
-
+        $this->probe = new \BlackfireProbe($headers['x-blackfire-query'][0]);
         // Stop if it failed
-        if (!$probe->enable()) {
-            return array();
+        if (!$this->probe->enable()) {
+            fwrite(STDERR, 'Could not start blackfire probe');
+
+            return;
+        }
+    }
+
+    /**
+     * Stop profiling and add Blackfire headers if needed
+     *
+     * @param array $headers
+     * @return array
+     */
+    public function handleHeaders($headers)
+    {
+        if ($this->probe) {
+            $this->probe->close();
+
+            // Return the header
+            $header = explode(':', $this->probe->getResponseLine(), 2);
+
+            $headers['x-' . $header[0]] = $header[1];
+
+            $this->probe = null;
         }
 
-        // Stop profiling once the request ends
-        $response->on('end', array($probe, 'close'));
-
-        // Return the header
-        $header = explode(':', $probe->getResponseLine(), 2);
-
-        return array('x-'.$header[0] => $header[1]);
+        return $headers;
     }
+
 }


### PR DESCRIPTION
I was creating a microservice and wanted to compare different methods.

While profiling I discovered that the /Blackfire/Bridge/ReactHttpServer was outdated.

After some modifications I was able to get it working.

This is my first public pull request, tips and improvements are more then welcome.

```
<?php
include_once __DIR__ . '/vendor/autoload.php';
$blackfire = new Blackfire\Bridge\ReactHttpServer();

$loop = React\EventLoop\Factory::create();

$server = new \React\Http\Server(function (\Psr\Http\Message\ServerRequestInterface $request) use ($blackfire) {
    $blackfire->handleRequest($request);
    sleep(5);
    $response = new \React\Http\Response(
        200,
        $blackfire->handleHeaders(['Content-Type' => 'text/plain']),
        "Hello World!\n"
    );

    return $response;
});

$socket = new React\Socket\Server('0.0.0.0:8080', $loop);

$server->listen($socket);

$loop->run();
```