### PR TITLE
Add support to define custom metric argument capture

### DIFF
--- a/src/Blackfire/Profile/Metric.php
+++ b/src/Blackfire/Profile/Metric.php
@@ -18,12 +18,12 @@ class Metric
     private $label;
     private $matchers = array();
 
-    public function __construct($name, $selectors = null)
+    public function __construct($name, $selectors = null, $indice = null, $matcher = null)
     {
         $this->name = $this->label = $name;
 
         foreach ((array) $selectors as $selector) {
-            $this->addCallee($selector);
+            $this->addCallee($selector, $indice, $matcher);
         }
     }
 
@@ -50,9 +50,9 @@ class Metric
     /**
      * @return MetricMatcher
      */
-    public function addCallee($selector)
+    public function addCallee($selector, $indice = null, $matcher = null)
     {
-        $this->matchers[] = $matcher = new MetricMatcher($selector);
+        $this->matchers[] = $matcher = new MetricMatcher($selector, $indice, $matcher);
 
         return $matcher;
     }

--- a/src/Blackfire/Profile/MetricMatcher.php
+++ b/src/Blackfire/Profile/MetricMatcher.php
@@ -16,9 +16,13 @@ class MetricMatcher
     private $selector;
     private $argument;
 
-    public function __construct($selector)
+    public function __construct($selector, $indice = null, $matcher = null)
     {
         $this->selector = $selector;
+
+        if ((null !== $indice) AND (null !== $matcher)) {
+            $this->selectArgument($indice, $matcher);
+        }
     }
 
     public function selectArgument($indice, $matcher)


### PR DESCRIPTION
From now it's possible to define via SDK custom argument capture settings like in .blackfire.yml file, ex.

```
use Blackfire\Profile\Metric;

// define a custom metric
$metric = new Metric('cache.write_calls', '=Cache::write', '1', '^');

// add it to the profile configuration
// to  be able to use it in assertions
$config->defineMetric($metric);
```
its equal to the same definition in .blackfire.yml file:

```
metrics:
  cache.write: # metric name
    label: "Cache::write() calls"
    matching_calls:
      php:
        - callee:
            selector: '=Cache::write' # aggregate the costs of all Cache::write calls
            argument: { 1: "^" }  # but create separate nodes by the first argument value
```

