### PR TITLE
Define assertions directly from your test

### DIFF
--- a/src/Blackfire/Bridge/PhpUnit/TestCaseTrait.php
+++ b/src/Blackfire/Bridge/PhpUnit/TestCaseTrait.php
@@ -59,6 +59,18 @@ trait TestCaseTrait
         return $profile;
     }
 
+    public function assertBlackfireIsSuccessful(ProfileConfiguration $configuration): void
+    {
+        try {
+            if ($configuration->hasAssertions()) {
+                $result = self::$blackfire->doGetProfile($configuration->getUuid());
+                self::assertEquals('successful', $result['report']['state']);
+            }
+        } catch (ExceptionInterface $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+    }
+
     protected function getBlackfireClientConfiguration()
     {
         return new ClientConfiguration();

--- a/src/Blackfire/Bridge/Symfony/BlackfiredHttpBrowser.php
+++ b/src/Blackfire/Bridge/Symfony/BlackfiredHttpBrowser.php
@@ -38,6 +38,11 @@ class BlackfiredHttpBrowser extends HttpBrowser
 
     private $profileTitle;
 
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
     public function __construct(BuildHelper $buildHelper)
     {
         $this->buildHelper = $buildHelper;
@@ -73,10 +78,15 @@ class BlackfiredHttpBrowser extends HttpBrowser
         return $this;
     }
 
+    public function setConfiguration(Configuration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
     public function request(string $method, string $uri, array $parameters = array(), array $files = array(), array $server = array(), string $content = null, bool $changeHistory = true)
     {
         if ($this->isProfilingEnabled()) {
-            $profileConfig = (new Configuration())->setTitle($this->profileTitle ?? sprintf('%s - %s', $uri, $method));
+            $profileConfig = $this->configuration ?? (new Configuration())->setTitle($this->profileTitle ?? sprintf('%s - %s', $uri, $method));
             if ($this->buildHelper->hasCurrentScenario()) {
                 $profileConfig->setScenario($this->buildHelper->getCurrentScenario());
             }


### PR DESCRIPTION
I want to be able to specify assertions directly in the test itself, not just in the .blackfire.yaml file.

You can see an example of a test below:
```
class BlackfireTest extends BlackfireTestCase
{
    use TestCaseTrait;

    protected const BLACKFIRE_SCENARIO_AUTO_START = false;

    /**
     * @group Blackfire
     *
     * @requires extension blackfire
     */
    public function testBlackfireSuccessesResponse()
    {
        $configuration = new Configuration();
        $configuration->assert('metrics.sql.queries.count == 1', 'SQL queries');
        $configuration->assert('metrics.http.requests.count == 1', 'HTTP Requests');
        $configuration->setUuid(Uuid::v4()->toRfc4122());

        $client = static::createBlackfiredHttpBrowserClient();
        $client->setConfiguration($configuration);

        $client->request(
            Request::METHOD_GET,
            '/blackfire?username=test',
            [],
            [],
            ['HTTP_ACCEPT' => 'application/json']
        );

        $this->assertBlackfireIsSuccessful($configuration);
    }
}
```
