### PR TITLE
Add support for the Symfony kernel browser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "behat/behat": "^3.8",
         "friends-of-behat/mink-extension": "^2.5",
         "friends-of-behat/mink-browserkit-driver": "^1.4",
+        "friends-of-behat/symfony-extension": "^2",
         "illuminate/support": "^8.81",
         "illuminate/console": "^8.81",
         "illuminate/queue": "^8.81",

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/BlackfireExtension.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/BlackfireExtension.php
@@ -23,6 +23,7 @@ use Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver\Blackfired
 use Blackfire\Bridge\Symfony\BlackfiredHttpBrowser;
 use Blackfire\Bridge\Symfony\BlackfiredKernelBrowser;
 use Blackfire\Build\BuildHelper;
+use FriendsOfBehat\SymfonyExtension\Driver\SymfonyDriver;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -78,10 +79,12 @@ class BlackfireExtension implements ExtensionInterface
             BlackfiredHttpBrowser::class,
             new Definition(BlackfiredHttpBrowser::class, array(new Reference(BuildHelper::class)))
         );
-        $container->setDefinition(
-            BlackfiredKernelBrowser::class,
-            new Definition(BlackfiredKernelBrowser::class, array(new Reference('fob_symfony.kernel')))
-        );
+        if (class_exists(SymfonyDriver::class)) {
+            $container->setDefinition(
+                BlackfiredKernelBrowser::class,
+                new Definition(BlackfiredKernelBrowser::class, array(new Reference('fob_symfony.kernel')))
+            );
+        }
 
         $container->setParameter('blackfire.environment', $config['blackfire_environment']);
         $container->setParameter('blackfire.build_name', $config['build_name']);

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/BlackfireExtension.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/BlackfireExtension.php
@@ -19,7 +19,9 @@ use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Blackfire\Bridge\Behat\BlackfireExtension\Event\BuildSubscriber;
 use Blackfire\Bridge\Behat\BlackfireExtension\Event\ScenarioSubscriber;
 use Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver\BlackfiredHttpBrowserFactory;
+use Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver\BlackfiredKernelBrowserFactory;
 use Blackfire\Bridge\Symfony\BlackfiredHttpBrowser;
+use Blackfire\Bridge\Symfony\BlackfiredKernelBrowser;
 use Blackfire\Build\BuildHelper;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -28,8 +30,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class BlackfireExtension implements ExtensionInterface
 {
-    private $minkExtensionFound = false;
-
     public function process(ContainerBuilder $container)
     {
     }
@@ -48,7 +48,7 @@ class BlackfireExtension implements ExtensionInterface
         }
 
         $minkExtension->registerDriverFactory(new BlackfiredHttpBrowserFactory());
-        $this->minkExtensionFound = true;
+        $minkExtension->registerDriverFactory(new BlackfiredKernelBrowserFactory());
     }
 
     public function configure(ArrayNodeDefinition $builder)
@@ -77,6 +77,10 @@ class BlackfireExtension implements ExtensionInterface
         $container->setDefinition(
             BlackfiredHttpBrowser::class,
             new Definition(BlackfiredHttpBrowser::class, array(new Reference(BuildHelper::class)))
+        );
+        $container->setDefinition(
+            BlackfiredKernelBrowser::class,
+            new Definition(BlackfiredKernelBrowser::class, array(new Reference('fob_symfony.kernel')))
         );
 
         $container->setParameter('blackfire.environment', $config['blackfire_environment']);

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfireDriver.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfireDriver.php
@@ -12,17 +12,7 @@
 namespace Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
-use Blackfire\Build\BuildHelper;
-use Symfony\Component\BrowserKit\AbstractBrowser;
 
 class BlackfireDriver extends BrowserKitDriver
 {
-    private $buildHelper;
-
-    public function __construct(AbstractBrowser $client, ?string $baseUrl = null, ?BuildHelper $buildHelper = null)
-    {
-        parent::__construct($client, $baseUrl);
-
-        $this->buildHelper = $buildHelper ?? BuildHelper::getInstance();
-    }
 }

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfireKernelBrowserDriver.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfireKernelBrowserDriver.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Blackfire SDK package.
+ *
+ * (c) Blackfire <support@blackfire.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver;
+
+use Blackfire\Bridge\Symfony\BlackfiredKernelBrowser;
+
+class BlackfireKernelBrowserDriver extends BlackfireDriver
+{
+    private $client;
+
+    private $baseUrl;
+
+    public function __construct(BlackfiredKernelBrowser $client, ?string $baseUrl = null)
+    {
+        parent::__construct($client, $baseUrl);
+
+        $client->enableBlackfire();
+        $this->baseUrl = $baseUrl;
+        $this->client = $client;
+    }
+
+    public function reset()
+    {
+        parent::reset();
+
+        parent::__construct($this->client, $this->baseUrl);
+    }
+}

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredHttpBrowserFactory.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredHttpBrowserFactory.php
@@ -37,7 +37,7 @@ class BlackfiredHttpBrowserFactory implements DriverFactory
     public function buildDriver(array $config)
     {
         if (!class_exists(BrowserKitDriver::class)) {
-            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "symfony" driver.');
+            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "blackfire" driver.');
         }
 
         return new Definition(BlackfireDriver::class, array(

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredKernelBrowserFactory.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredKernelBrowserFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Blackfire SDK package.
+ *
+ * (c) Blackfire <support@blackfire.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver;
+
+use Behat\Mink\Driver\BrowserKitDriver;
+use Behat\MinkExtension\ServiceContainer\Driver\DriverFactory;
+use Blackfire\Bridge\Symfony\BlackfiredKernelBrowser;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class BlackfiredKernelBrowserFactory implements DriverFactory
+{
+    public function getDriverName()
+    {
+        return 'blackfire_symfony';
+    }
+
+    public function supportsJavascript()
+    {
+        return false;
+    }
+
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+
+    public function buildDriver(array $config)
+    {
+        if (!class_exists(BrowserKitDriver::class)) {
+            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "symfony" driver.');
+        }
+
+        return new Definition(BlackfireKernelBrowserDriver::class, array(
+            new Reference(BlackfiredKernelBrowser::class),
+            '%mink.base_url%',
+        ));
+    }
+}

--- a/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredKernelBrowserFactory.php
+++ b/src/Blackfire/Bridge/Behat/BlackfireExtension/ServiceContainer/Driver/BlackfiredKernelBrowserFactory.php
@@ -14,6 +14,7 @@ namespace Blackfire\Bridge\Behat\BlackfireExtension\ServiceContainer\Driver;
 use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\MinkExtension\ServiceContainer\Driver\DriverFactory;
 use Blackfire\Bridge\Symfony\BlackfiredKernelBrowser;
+use FriendsOfBehat\SymfonyExtension\Driver\SymfonyDriver;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -37,7 +38,10 @@ class BlackfiredKernelBrowserFactory implements DriverFactory
     public function buildDriver(array $config)
     {
         if (!class_exists(BrowserKitDriver::class)) {
-            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "symfony" driver.');
+            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "blackfire_symfony" driver.');
+        }
+        if (!class_exists(SymfonyDriver::class)) {
+            throw new \RuntimeException('Install "friends-of-behat/symfony-extension" (drop-in replacement for "behat/symfony2-extension") in order to use the "blackfire_symfony" driver.');
         }
 
         return new Definition(BlackfireKernelBrowserDriver::class, array(

--- a/src/Blackfire/Bridge/Symfony/BlackfiredKernelBrowser.php
+++ b/src/Blackfire/Bridge/Symfony/BlackfiredKernelBrowser.php
@@ -67,10 +67,6 @@ class BlackfiredKernelBrowser extends KernelBrowser
             }
 
             $_SERVER += array(
-                'SERVER_ADDR' => 'localhost',
-                'SERVER_SOFTWARE' => 'Blackfire',
-                'SERVER_PORT' => 80,
-                'HTTPS' => '',
                 'HTTP_HOST' => 'localhost',
                 'REQUEST_URI' => $request->getPathInfo(),
                 'HTTP_USER_AGENT' => 'BlackfireKernelBrowser',

--- a/src/Blackfire/Bridge/Symfony/BlackfiredKernelBrowser.php
+++ b/src/Blackfire/Bridge/Symfony/BlackfiredKernelBrowser.php
@@ -67,6 +67,10 @@ class BlackfiredKernelBrowser extends KernelBrowser
             }
 
             $_SERVER += array(
+                'SERVER_ADDR' => 'localhost',
+                'SERVER_SOFTWARE' => 'Blackfire',
+                'SERVER_PORT' => 80,
+                'HTTPS' => '',
                 'HTTP_HOST' => 'localhost',
                 'REQUEST_URI' => $request->getPathInfo(),
                 'HTTP_USER_AGENT' => 'BlackfireKernelBrowser',


### PR DESCRIPTION
Currently the Behat driver only supports doing real HTTP requests when running the Behat tests. But it is much better to use the Symfony kernel browser which just simulates the requests without actually performing them, thus making the Behat tests much faster.

The Blackfire PHP SDK already contained a class, `Blackfire\Bridge\Symfony\BlackfiredKernelBrowser` which could be used to activate Blackfire when using the Symfony kernel browser but this class was not used anywhere. This PR just adds the configuration and drivers needed to be able to use this class.

I have named the new driver with the `blackfire_symfony` name, so that this could be used like this:

```
        Behat\MinkExtension:
            sessions:
                blackfire:
                    blackfire_symfony: ~
```
If instead of `blackfire_symfony` we used `blackfire` we would use the existing driver which does real HTTP requests.

There is one issue which I have been unable to solve: currently when you run the behat tests with this new driver, any request performed by the tests is understood by blackfire.io as coming from a command, not an HTTP request. So it will apply the asserttions that you have defined for your commands, not your requests. I tried to add more parameters to the `$_SERVER` variable but this did not seem to help. Since I don't have access to the details of how the probe or the site identifies a request as coming from a command or a real request I could not do anything else. If someone has these details and could share them, I can add whatever is needed